### PR TITLE
26: x_icon null safety compile warning fix

### DIFF
--- a/flutter-packages/x_icon/lib/src/icon.dart
+++ b/flutter-packages/x_icon/lib/src/icon.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:json_annotation/json_annotation.dart';
+
 import 'icon_data.dart';
 
 part 'icon.g.dart';
@@ -45,14 +46,22 @@ class XIcon extends StatelessWidget {
         );
       case XIconType.CUPERTINO_NATIVE:
         throw FlutterError("cupertino icons are not yet supported");
+      default:
+        break;
     }
 
+    TextStyle? errorStyle;
+    if (Theme.of(context) != null) {
+      var themeData = Theme.of(context);
+      if (themeData.textTheme != null) {
+        var textTheme = themeData.textTheme;
+        errorStyle =
+            textTheme.caption!.copyWith(color: Theme.of(context).errorColor);
+      }
+    }
     return Text(
       "ERROR: no valid remote icon data has passed",
-      style: Theme.of(context)!
-          .textTheme!
-          .caption!
-          .copyWith(color: Theme.of(context).errorColor),
+      style: errorStyle,
     );
   }
 


### PR DESCRIPTION
Updated icon.dart to add a default case so the section of code with the warnings becomes theoretically reachable, and constructed the style for the returned Text widget in a way that makes the compiler happy.